### PR TITLE
docs/devel/networking: unbreak URL

### DIFF
--- a/docs/devel/networking.md
+++ b/docs/devel/networking.md
@@ -379,5 +379,6 @@ VM instance. Despite that, the only IP address reported is the IPv6 address,
 which implicitly highly encourages IPv6 communication towards the VM instance.
 
 On a final note, there is a difference that impacts the user experience when
-using masquerade binding for IPv6 addresses; the VMI IP must be [manually
-configured by the user](https://kubevirt.io/user-guide/#/creation/interfaces-and-networks?id=masquerade-ipv6-support).
+using masquerade binding for IPv6 addresses: until we introduce support of IPv6
+[router advertisement](https://github.com/kubevirt/kubevirt/pull/4581),
+the VMI IP must be [manually configured by the user](https://kubevirt.io/user-guide/#/creation/interfaces-and-networks?id=masquerade-ipv4-and-ipv6-dual-stack-support).


### PR DESCRIPTION
This PR unbreaks a URL and explains why IPv6 is different from IPv4 with regards to
masquerade binding method.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>


/cc @AlonaKaplan @maiqueb